### PR TITLE
Discrete Simulation of Riemann-Liouville fBm

### DIFF
--- a/src/univariate/FBM.jl
+++ b/src/univariate/FBM.jl
@@ -201,3 +201,68 @@ function rand(p::Vector{FBM}; fbm::Bool=true, rtype::Symbol=:fft)
   else
   end
 end
+
+
+
+# Implementation of "exact discrete" method for simulating Riemann-Liouville fBm
+# Based on Muniandy, S. & Lim, S. Modeling of locally self-similar processes using multifractional
+# Brownian motion of Riemann-Liouville type. Physical Review E 63, 046104. ISSN: 1063-
+# 651X (2001).
+# Specifically, Eqn. 17, 18 and 19.
+# From Muniandy 2001, Reimann-Liouville fBm is defined as, 
+# B_H(t)=\frac{1}{\Gamma(H+0.5)}\int^{t}_{0}(t-s)^(H-0.5)dB(s), t\geq0.
+# Here we focus on the discrete time t_j=j\Delta t approximation,
+# B_H(t_j)=\frac{1}{\Gamma(H+0.5)}\sum^{j}_{i=1}\int^{i\Delta t}_{(i-1)\Delta t}(t_j-\tau)^(H-0.5)dB(\tau)
+# The exact solution to the interior integral results in a weighting function that we have implemented here with the :Exact key.
+# An "improved" weighting function was proposed by Rambaldi, S. & Pinazza, O. An accurate fractional Brownian motion generator. Physica A
+# 208, 21–30 (1994). We have implemented this here with the :Improved key.
+
+function rand_RL_Disc(p::FBM,fbm::Bool=true,w_type::Symbol=:Exact)
+# We are going to require that the time points are evenly spaced to keep things simple
+dt = unique(diff(p.t))
+if length(dt) != 1
+	error("For this simulation technique, the fBm process must be sampled across a uniform temporal grid")
+end
+
+dt = dt[1]
+
+w_mat = zeros(p.n-1,p.n-1) # Prealocate a weight matrix. Note that this will be upper triangular
+
+if w_type==:Exact
+  for j=1:p.n-1
+	  for i=1:j
+		  w_mat[i,j] = ExactWeight(p.h,(j-i+1)*dt,dt)
+	  end
+  end
+elseif w_type==:Improved
+	for j=1:p.n-1
+	  for i=1:j
+		  w_mat[i,j] = ImprovedWeight(p.h,(j-i+1)*dt,dt)
+	  end
+	end
+else
+  error("Unknown symbol. Options are :Exact and :Improved")
+end
+	
+  # Multiply a vector of white noise by the weight matrix and scale appropriately.
+	X = squeeze(sqrt(2)*(randn(p.n-1)'*w_mat),1).*sqrt(dt)
+	
+	insert!(X, 1, 0.0)  # Snap to zero. Not clear if this causes a discontinuity in the correlation structure. 
+  #It is worth considering alternative for the above line: generate path X of length p.n, then let X = X-X[1].
+	
+return X
+end
+
+function ExactWeight(H::Float64,t::Float64,dt::Float64)
+	nom = t^(H+.5)-(t-dt)^(H+.5)
+	denom = gamma(H+.5)*(H+.5)*dt
+	weight = nom/denom
+	return weight
+end
+
+function ImprovedWeight(H::Float64,t::Float64,dt::Float64)
+	nom = t^(2*H)-(t-dt)^(2*H)
+	denom = 2*H*dt
+	weight = sqrt(nom/denom)/gamma(H+.5)
+	return weight
+end

--- a/src/univariate/FBM.jl
+++ b/src/univariate/FBM.jl
@@ -110,7 +110,7 @@ end
 ### T. Dieker, Simulation of Fractional Brownian Motion, master thesis, 2004.
 ### The complexity of the algorithm is O(n^3), where n is the number of FBM samples.
 function rand_chol(p::FBM; fbm::Bool=true)
-  println("Using Cholesky decomposition")
+  
   w = (chol(autocov(p))')*randn(p.n-1)
 
   # If fbm is true return FBM, otherwise return FGN


### PR DESCRIPTION
Discrete Simulation of Riemann-Liouville fBm based on 

_Rambaldi, S. & Pinazza, O. An accurate fractional Brownian motion generator. Physica A 208, 21–30 (1994)_ 

and

_Muniandy, S. & Lim, S. Modeling of locally self-similar processes using multifractional
Brownian motion of Riemann-Liouville type. Physical Review E 63, 046104. ISSN: 1063-
651X (2001)._

I included a note about the use of `insert!` in the comments. Not clear to me at this point if one approach is better than the other.

Additionally, may want to consider adding a way to easily recover the weight/covariance matrix used in a given simulation. Since this is the most computationally expensive part of the process, if we happen to want to generate many paths of the same length with the same Hurst parameter, it would be nice to be able to reuse this variable and it would save a significant amount of time.


