### PR TITLE
Cholesky modifications

### DIFF
--- a/src/univariate/FBM.jl
+++ b/src/univariate/FBM.jl
@@ -266,3 +266,22 @@ function ImprovedWeight(H::Float64,t::Float64,dt::Float64)
 	weight = sqrt(nom/denom)/gamma(H+.5)
 	return weight
 end
+
+
+function CholUpdate(r0::Array{Float64,2},A::Array{Float64,2})
+# r0 is a lower triangular matrix found via cholesky decomposition of
+# A(1:end-1,1:end-1), therefore r0 is a matrix of size (N-1)-by-(N-1) when A
+# is of size N-by-N. A is a positive symetric semidefinite matrix by construction.
+    
+    m = size(A,1); # Assumes A is square
+    r1 = zeros(m,m)
+    r1[1:end-1,1:end-1] = r0
+    
+  @inbounds  for i=1:m-1
+        r1[m,i] =  (1./r1[i,i])*(A[m,i]-sum(r1[m,1:i].*r1[i,1:i]))[1]
+    end
+
+    r1[m,m] = sqrt(A[m,m]-sum(r1[m,1:m-1].*r1[m,1:m-1]))[1]
+ 
+    return r1
+end

--- a/test/FBM.jl
+++ b/test/FBM.jl
@@ -15,5 +15,5 @@ rand([p, p], rtype=:chol)
 
 P = autocov(p)
 Q = autocov(q)
-c = chol(P)
-CholUpdate(Q,convert(Array{Float64,2},c))
+c = chol(P)'
+CholUpdate(convert(Array{Float64,2},c),Q)

--- a/test/FBM.jl
+++ b/test/FBM.jl
@@ -3,7 +3,8 @@ using Base.Test
 
 @test convert(FGN, FBM(0:0.5:10, 0.4)) == FGN(0.757858283255199,0.4)
 
-p = FBM(0:1/2^10:1, 0.4)
+p = FBM(0:.1:.1*100, 0.4)
+q = FBM(0:.1:.1*101, 0.4)
 
 rand(p)
 rand(p, fbm=false)
@@ -11,3 +12,8 @@ rand([p, p])
 rand(p, rtype=:chol)
 rand(p, fbm=false, rtype=:chol)
 rand([p, p], rtype=:chol)
+
+P = autocov(p)
+Q = autocov(q)
+c = chol(P)
+CholUpdate(Q,convert(Array{Float64,2},c))


### PR DESCRIPTION
@scidom, I made a new function `CholUpdate` for efficient updates to the cholesky decomposition of the covariance matrix. The use case is, we have a path `p1` of length `N` and want to create a path `p2` of length `N+1`. Given `autocov(p2)` and `chol(autocov(p1))`, we can get the new entries of `chol(autocov(p2))` without having to compute the full cholesky decomposition since a `N`-by-`N` portion of it is contained within `chol(autocov(p1))`.

After testing the speed with `BenchmarkTools.jl` package, it looks like the average speedup is around 52% for the path lengths that I tested. I put two figures below (same data, one log-log scale and one not) showing computation time comparisons between `CholUpdate` and Julia's built-in `chol` function.

I also added a few lines [here](https://github.com/rand5/Brownian.jl/blob/master/test/FBM.jl#L16) to test the code.

![test1](https://cloud.githubusercontent.com/assets/17629404/24726633/1ecb4aa2-1a21-11e7-853a-668ee83aec67.png)
![test2](https://cloud.githubusercontent.com/assets/17629404/24726782/93cc6e6c-1a21-11e7-9b89-7e385322789a.png)
